### PR TITLE
Specify minimum npm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ notifications:
 
 install:
   - curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo -E bash -
-  - sudo apt-get install -y nodejs
+  - sudo apt-get install -y nodejs npm
 
 before_script:
   - ./build-package

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 3.0.0-rc.5-1
 Section: net
 Priority: optional
 Architecture: all
-Depends: nodejs (>= 6.13.0), npm (>= 6.4.1), bash
+Depends: nodejs (>= 6.13.0), npm (>= 3.10.10), bash
 Maintainer: Maxime Poulin <thelounge@max-p.me>
 Description: A self-hosted, web-based IRC client
 Homepage: https://thelounge.chat

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 3.0.0-rc.5-1
 Section: net
 Priority: optional
 Architecture: all
-Depends: nodejs (>= 6.13.0), npm, bash
+Depends: nodejs (>= 6.13.0), npm (>= 6.4.1), bash
 Maintainer: Maxime Poulin <thelounge@max-p.me>
 Description: A self-hosted, web-based IRC client
 Homepage: https://thelounge.chat


### PR DESCRIPTION
Versions are listed on https://nodejs.org/en/download/releases/

It appears that some users have up to date node version, but their npm version is older than what it should be, causing random bugs to appear during sqlite installation.

Like this:
![ehm-](https://user-images.githubusercontent.com/613331/49863823-cf3f6800-fe09-11e8-8ba0-c2b19efacf5d.png)
