### PR TITLE
Delete clean

### DIFF
--- a/clean
+++ b/clean
@@ -1,4 +1,0 @@
-#!/bin/bash
-cd $(dirname ${BASH_SOURCE[0]})
-
-rm -rf pkg/ deb/


### PR DESCRIPTION
`build-package` handles this already.