### PR TITLE
Bump thelounge to v3.0.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Package: thelounge
-Version: 3.0.0-rc.6-1
+Version: 3.0.0-1
 Section: net
 Priority: optional
 Architecture: all


### PR DESCRIPTION
This will break CI for now, because the release hasn't made it to npm registry yet. I'll re-run the CI when it does.