### PR TITLE
Do not abort installation if sqlite fails to install

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -12,7 +12,8 @@ node /usr/lib/node_modules/thelounge/node_modules/yarn/bin/yarn.js \
 	--non-interactive \
 	--no-lockfile \
 	--no-default-rc \
-	--production
+	--production \
+|| echo '[!!] Failed to install sqlite3 module correctly, The Lounge will continue working, but you might want to fix this.'
 
 echo 'Moving sqlite3 module to The Lounge'
 


### PR DESCRIPTION
The script is setup in such a way that it fails to complete package installation if any of the subcommands fail.

The Lounge can work perfectly fine if sqlite fails to install, so allow it to fail during package installation. ~~I also added `Suggests: build-essential` which solve this troubles of compiling sqlite module on ARM machines.~~