### PR TITLE
Update system.service to ensure DNS is ready at boot

### DIFF
--- a/systemd/system.service
+++ b/systemd/system.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=The Lounge (IRC client)
 After=network.target
+After=network-online.target
+Wants=network-online.target
+
 
 [Service]
 User=thelounge

--- a/systemd/system.service
+++ b/systemd/system.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=The Lounge (IRC client)
-After=network.target
 After=network-online.target
 Wants=network-online.target
 


### PR DESCRIPTION
Add "After=network-online.target" and "Wants=network-online.target" to
ensure DNS is be up and working before thelounge service started.

On my machine I manually updated
"/usr/lib/systemd/system/thelounge.service", I assume that changing it
in system.service in the repo would reflect the change in
thelounge.service, but I did not verify in the code

Closes #65