### PR TITLE
Upgrade TravisCI to Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 sudo: required
 
 language: minimal


### PR DESCRIPTION
Xenial is End-of-Life and not supported anymore, upgrade to the next oldest LTS.