### PR TITLE
Use yarn to install TL

### DIFF
--- a/build-package
+++ b/build-package
@@ -16,25 +16,40 @@ NPMVERSION=$(grep Version debian/control | awk -F': ' '{print $2}' | sed -E 's/-
 STARTDIR="$(pwd)"
 DESTDIR="$STARTDIR/pkg"
 OUTDIR="$STARTDIR/deb"
-NPMCACHE="$STARTDIR/npm_cache"
+CACHE="$STARTDIR/cache"
+MODULES_DIR="$DESTDIR/usr/lib/thelounge/node_modules"
+export HOME="$STARTDIR" # because yarn is stupid and tries to mess with the user config files
 
 echo "Building $NPMVERSION..."
 
 # Remove potential leftovers from a previous build
 rm -rf "$DESTDIR" "$OUTDIR"
 
+install -dm755 "$DESTDIR/usr/bin"
+install -dm755 "$MODULES_DIR/thelounge"
+
+# Fetch the lock file so that we actually get the pinned deps that we want
+curl -O "https://raw.githubusercontent.com/thelounge/thelounge/$NPMVERSION/yarn.lock"
+
 # Install the package itself
- npm install -g --no-optional --cache "$NPMCACHE" --prefix "$DESTDIR/usr" \
+# we on purposes don't use yarn global add, because with it --ignore-scripts
+# is pointless: https://github.com/yarnpkg/yarn/issues/8291 but we tried
+yarn add --no-default-rc --frozen-lockfile \
+	--prod --non-interactive --ignore-scripts \
+	--cache-folder "$CACHE" --modules-folder "$MODULES_DIR" \
 	"thelounge@${NPMVERSION}"
 
 # Write .thelounge_home to set correct system config directory
-echo "/etc/thelounge" > "$DESTDIR/usr/lib/node_modules/thelounge/.thelounge_home"
+echo "/etc/thelounge" > "$MODULES_DIR/thelounge/.thelounge_home"
+
+# manually write the binary link
+ln -s "${MODULES_DIR#$DESTDIR}/thelounge/index.js" "$DESTDIR/usr/bin/thelounge"
 
 # Install configuration/home directory
 install -dm775 "$DESTDIR/etc/thelounge"
 install -dm770 "$DESTDIR/etc/thelounge/users"
 install -Dm660 \
-	"$DESTDIR/usr/lib/node_modules/thelounge/defaults/config.js" \
+	"$MODULES_DIR/thelounge/defaults/config.js" \
 	"$DESTDIR/etc/thelounge/config.js"
 
 # Install systemd units

--- a/debian/control
+++ b/debian/control
@@ -1,12 +1,10 @@
 Package: thelounge
-Version: 4.3.0
+Version: 4.3.1~rc.1-10
 Section: net
 Priority: optional
 Architecture: all
 Depends: nodejs (>= 12.13.0), bash, init-system-helpers
-Provides: lounge
-Conflicts: lounge
-Replaces: lounge
+Recommends: python, build-essential
 Maintainer: The Lounge maintainers team <security@thelounge.chat>
 Description: A self-hosted, web-based IRC client
 Homepage: https://thelounge.chat

--- a/debian/postinst
+++ b/debian/postinst
@@ -3,21 +3,24 @@ set -euo pipefail
 
 [[ "$1" == "configure" ]] || exit 0
 
-echo 'Downloading sqlite3 module for your specific installation'
-
-# Install sqlite3 into a clean folder with yarn binary that comes with The Lounge
-node /usr/lib/node_modules/thelounge/node_modules/yarn/bin/yarn.js \
-	--cache-folder /usr/lib/node_modules/thelounge/debian_postinst_yarn_cache \
-	--cwd /usr/lib/node_modules/thelounge \
-	--non-interactive \
-	--no-default-rc \
-	--production \
-|| echo '[!!] Failed to install sqlite3 module correctly, The Lounge will continue working, but you might want to fix this.'
-
-echo 'Removing leftover files'
-
-# Remove left over folder which is no longer required
-rm --recursive --force /usr/lib/node_modules/thelounge/debian_postinst_yarn_cache/
+echo 'Downloading or building sqlite3 module for your specific installation'
+echo This might take several minutes, depending on your processor speed
+pushd /usr/lib/thelounge/node_modules/sqlite3
+garbage_folder=./garbage42
+install -dm 750 "$garbage_folder"
+# make sure we aren't writing to any other dir
+# in theory the devdir should be enough but let's future proof it
+export npm_config_devdir="$garbage_folder"
+export HOME="$garbage_folder"
+./node_modules/.bin/node-pre-gyp clean
+./node_modules/.bin/node-pre-gyp install --fallback-to-build
+ret=$?
+rm -rf "$garbage_folder"
+popd
+if [ $ret -ne 0 ]
+then
+	echo '[!!] Failed to install sqlite3 module correctly, The Lounge will continue working, but you might want to fix this.'
+fi
 
 if ! getent group thelounge >/dev/null; then
 	echo 'Creating thelounge group'


### PR DESCRIPTION
Other improvements:
* Make sure that we use the package lock file wherever we can.
* only fix the sqlite3 dep, leave the other packages alone in the
  post install script

This also executes yarn without the global verb, problem being
that yarn refuses to honor the command line flags as given:
https://github.com/yarnpkg/yarn/issues/8291