### PR TITLE
postInstall: Remove -euo pipefail

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,11 +1,9 @@
 #!/bin/bash
-set -euo pipefail
-
 [[ "$1" == "configure" ]] || exit 0
 
 echo 'Downloading or building sqlite3 module for your specific installation'
 echo This might take several minutes, depending on your processor speed
-pushd /usr/lib/thelounge/node_modules/sqlite3
+pushd /usr/lib/thelounge/node_modules/sqlite3 || exit 1
 garbage_folder=./garbage42
 install -dm 750 "$garbage_folder"
 # make sure we aren't writing to any other dir
@@ -16,7 +14,7 @@ export HOME="$garbage_folder"
 ./node_modules/.bin/node-pre-gyp install --fallback-to-build
 ret=$?
 rm -rf "$garbage_folder"
-popd
+popd || exit 1
 if [ $ret -ne 0 ]
 then
 	echo '[!!] Failed to install sqlite3 module correctly, The Lounge will continue working, but you might want to fix this.'


### PR DESCRIPTION
This is generally considered to be a bad idea anyhow and has issues in our case.
The sqlite installation may very well fail, which is fine. Prior to this commit it would have aborted the whole post script