### PR TITLE
Force archive compression to xz

### DIFF
--- a/build-package
+++ b/build-package
@@ -61,4 +61,4 @@ install -Dm644 "$STARTDIR/systemd/user.service" \
 # Build .deb
 mkdir "$DESTDIR/DEBIAN" "$OUTDIR"
 cp "$STARTDIR/debian/"* "$DESTDIR/DEBIAN/"
-dpkg-deb --root-owner-group --build "$DESTDIR" "$OUTDIR"
+dpkg-deb -Z xz --root-owner-group --build "$DESTDIR" "$OUTDIR"


### PR DESCRIPTION
Debian can't cope with zstd compression until bookworm Reported in https://github.com/thelounge/thelounge-deb/issues/82