### PR TITLE
workflows/build.yml: bump softprops/action-gh-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,6 @@ jobs:
 
       - name: Release
         if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && matrix.node_version == '22.x' }}
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: deb/*.deb


### PR DESCRIPTION
Uses non-deprecated versions of node.js

v3 did ship 6 days ago but uses node 24; we can update to that later.